### PR TITLE
Fix artifact name conflict when workflow analyze many images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
         working_directory=$(realpath ${{ inputs.working-directory }})
         bom_artifact_name="${{ inputs.image-name }}"
         # Remove the registry from the image name
-        bom_artifact_name="${sbom_name##*/}.docker-bom.json"
+        bom_artifact_name="${bom_artifact_name##*/}.docker-bom.json"
         echo "working-directory=$working_directory" >> $GITHUB_OUTPUT
         echo "bom-artifact-name=$bom_artifact_name" >> $GITHUB_OUTPUT
         echo "bom-path=$working_directory/build/reports/bom.json" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,8 @@ runs:
       run: |
         working_directory=$(realpath ${{ inputs.working-directory }})
         bom_artifact_name="${{ inputs.image-name }}"
-        # Remove the registry from the image name
+        # Remove registry and version from the image name to get the artifact name
+        bom_artifact_name=${bom_artifact_name%:*}
         bom_artifact_name="${bom_artifact_name##*/}.docker-bom.json"
         echo "working-directory=$working_directory" >> $GITHUB_OUTPUT
         echo "bom-artifact-name=$bom_artifact_name" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,11 @@ runs:
       id: context
       run: |
         working_directory=$(realpath ${{ inputs.working-directory }})
+        bom_artifact_name="${{ inputs.image-name }}"
+        # Remove the registry from the image name
+        bom_artifact_name="${sbom_name##*/}.docker-bom.json"
         echo "working-directory=$working_directory" >> $GITHUB_OUTPUT
+        echo "bom-artifact-name=$bom_artifact_name" >> $GITHUB_OUTPUT
         echo "bom-path=$working_directory/build/reports/bom.json" >> $GITHUB_OUTPUT
         echo "has-role=${{ inputs.role-to-assume != '' }}" >> $GITHUB_OUTPUT
         echo "is-ecr=${{ inputs.aws-region != '' }}" >> $GITHUB_OUTPUT
@@ -87,7 +91,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: "!cancelled()"
       with:
-        name: docker-bom.json
+        name: ${{ steps.context.outputs.bom-artifact-name }}
         retention-days: ${{ inputs.report-retention-days }}
         path: ${{ steps.context.outputs.bom-path }}
 


### PR DESCRIPTION
We use the image name without the repository to generate the artifact filename.

Tested with :   https://github.com/kronostechnologies/kronos-crm/actions/runs/7620387158?pr=10915

![image](https://github.com/equisoft-actions/docker-sbom/assets/617714/17c7d9b4-efe8-44ed-a05e-ea26e81dd7e0)
